### PR TITLE
fix: GitHub link is broken

### DIFF
--- a/packages/www/src/App.vue
+++ b/packages/www/src/App.vue
@@ -39,7 +39,7 @@ type Link =
 const links: Link[] = [
 	{
 		name: 'github',
-		href: 'https://github.com/legallyiris',
+		href: 'https://github.com/irimoe',
 		icon: faGithub,
 	},
 	{


### PR DESCRIPTION
Hi iris/willow, I discovered your website on [Cloudflare Radar](https://radar.cloudflare.com/scan/search?q=iri.moe&type=url) earlier today by chance (lol).

I found this issue and decided to suggest a fix with this PR.

There's another broken link to [git.gay](https://git.gay/iris) but I don't know how to fix that.